### PR TITLE
Reduce redundant hints

### DIFF
--- a/hanabi.py
+++ b/hanabi.py
@@ -4,7 +4,7 @@ import random
 import sys
 import copy
 import time
-from enum import IntEnum, Enum, unique
+from enum import Enum, unique
 from typing import Final
 
 GREEN = 0
@@ -18,7 +18,7 @@ COLORNAMES = ["green", "yellow", "white", "blue", "red"]
 COUNTS = [3, 2, 2, 2, 1]
 
 
-class Intent(IntEnum):
+class Intent(Enum):
     PLAY = 2
     DISCARD = 3
     CAN_DISCARD = 128

--- a/hanabi.py
+++ b/hanabi.py
@@ -19,7 +19,6 @@ COUNTS = [3, 2, 2, 2, 1]
 
 
 class Intent(IntEnum):
-    KEEP = 0
     PLAY = 2
     DISCARD = 3
     CAN_DISCARD = 128
@@ -658,7 +657,7 @@ class TimedPlayer:
 CANDISCARD = 128
 
 
-def format_intention(i: int | str | Intent) -> str:
+def format_intention(i: int | str | Intent | None) -> str:
     if isinstance(i, str):
         return i
     if i == PLAY:
@@ -731,7 +730,7 @@ def pretend(action, knowledge, intentions, hand, board):
         elif action == DISCARD and i in {Intent.DISCARD, Intent.CAN_DISCARD}:
             pos = True
             predictions.append(DISCARD)
-            if i == DISCARD:
+            if i == Intent.DISCARD:
                 score += 2
             else:
                 score += 1

--- a/hanabi.py
+++ b/hanabi.py
@@ -142,8 +142,9 @@ class Action:
 
 
 class Player:
-    def __init__(self, name, hand_size=5):
+    def __init__(self, name, pnr, hand_size=5):
         self.name = name
+        self.pnr = pnr
         self._hand_size: Final[int] = hand_size
 
         self.explanation = []
@@ -207,7 +208,7 @@ def update_knowledge(knowledge, used):
 
 class InnerStatePlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name)
+        super().__init__(name, pnr)
 
     def get_action(
         self, nr, hands, knowledge, trash, played, board, valid_actions, hints
@@ -273,9 +274,8 @@ class InnerStatePlayer(Player):
 
 class OuterStatePlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name)
+        super().__init__(name, pnr)
         self.hints = {}
-        self.pnr = pnr
 
     def get_action(
         self, nr, hands, knowledge, trash, played, board, valid_actions, hints
@@ -410,9 +410,8 @@ class SelfRecognitionPlayer(Player):
     gothint: tuple[Action, int] | None
 
     def __init__(self, name, pnr, other=OuterStatePlayer):
-        super().__init__(name)
+        super().__init__(name, pnr)
         self.hints = {}
-        self.pnr = pnr
         self.gothint = None
         self.last_knowledge = []
         self.last_played = []
@@ -799,9 +798,8 @@ def format_knowledge(k):
 
 class IntentionalPlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name)
+        super().__init__(name, pnr)
         self.hints = {}
-        self.pnr = pnr
         self.gothint = None
         self.last_knowledge = []
         self.last_played = []
@@ -956,9 +954,8 @@ class IntentionalPlayer(Player):
 
 class SelfIntentionalPlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name)
+        super().__init__(name, pnr)
         self.hints = {}
-        self.pnr = pnr
         self.gothint = None
         self.last_knowledge = []
         self.last_played = []
@@ -1172,9 +1169,8 @@ for c in ALL_COLORS:
 
 class SamplingRecognitionPlayer(Player):
     def __init__(self, name, pnr, other=IntentionalPlayer, maxtime=5000):
-        super().__init__(name)
+        super().__init__(name, pnr)
         self.hints = {}
-        self.pnr = pnr
         self.gothint = None
         self.last_knowledge = []
         self.last_played = []
@@ -1356,9 +1352,8 @@ class SamplingRecognitionPlayer(Player):
 
 class FullyIntentionalPlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name)
+        super().__init__(name, pnr)
         self.hints = {}
-        self.pnr = pnr
         self.gothint = None
         self.last_knowledge = []
         self.last_played = []

--- a/hanabi.py
+++ b/hanabi.py
@@ -97,6 +97,10 @@ class Action:
         PLAY = 2
         DISCARD = 3
 
+        @property
+        def display_name(self) -> str:
+            return self.name.replace("_", " ").title()
+
         def __str__(self) -> str:
             return str(self.value)
 
@@ -654,10 +658,7 @@ class TimedPlayer:
         return self.explanation
 
 
-CANDISCARD = 128
-
-
-def format_intention(i: int | str | Intent | None) -> str:
+def format_intention(i: str | Intent | None) -> str:
     if isinstance(i, str):
         return i
     if i == Intent.PLAY:
@@ -987,15 +988,10 @@ class SelfIntentionalPlayer(Player):
         if action:
             self.explanation.append(
                 ["What you want me to do"]
-                + list(
-                    map(
-                        format_intention,
-                        (
-                            x.value if isinstance(x, Action.ActionType) else None
-                            for x in action
-                        ),
-                    )
-                )
+                + [
+                    x.display_name if isinstance(x, Action.ActionType) else "Keep"
+                    for x in action
+                ]
             )
             for i, a in enumerate(action):
                 if a == Action.ActionType.PLAY and (

--- a/hanabi.py
+++ b/hanabi.py
@@ -96,7 +96,7 @@ PLAY = 2
 DISCARD = 3
 
 
-class Action(object):
+class Action:
     def __init__(self, type, pnr=None, col=None, num=None, cnr=None):
         self.type = type
         self.pnr = pnr

--- a/hanabi.py
+++ b/hanabi.py
@@ -1504,7 +1504,7 @@ class Game(object):
     def perform(self, action):
         for p in self.players:
             p.inform(action, self.current_player, self)
-        if format:
+        if self.format:
             print(
                 "MOVE:",
                 self.current_player,

--- a/hanabi.py
+++ b/hanabi.py
@@ -587,7 +587,7 @@ COUNT = 0
 CAREFUL = True
 
 
-class TimedPlayer(object):
+class TimedPlayer:
     def __init__(self, name, pnr):
         self.name = name
         self.explanation = []
@@ -1460,7 +1460,7 @@ def format_hand(hand):
     return ", ".join(list(map(format_card, hand)))
 
 
-class Game(object):
+class Game:
     def __init__(self, players, log=sys.stdout, format=0):
         self.players = players
         self.hits = 3
@@ -1718,7 +1718,7 @@ class Game(object):
             self.log.close()
 
 
-class NullStream(object):
+class NullStream:
     def write(self, *args):
         pass
 

--- a/hanabi.py
+++ b/hanabi.py
@@ -4,6 +4,7 @@ import random
 import sys
 import copy
 import time
+from enum import IntEnum
 from typing import Final
 
 GREEN = 0
@@ -15,6 +16,13 @@ ALL_COLORS = [GREEN, YELLOW, WHITE, BLUE, RED]
 COLORNAMES = ["green", "yellow", "white", "blue", "red"]
 
 COUNTS = [3, 2, 2, 2, 1]
+
+
+class Intent(IntEnum):
+    KEEP = 0
+    PLAY = 2
+    DISCARD = 3
+    CAN_DISCARD = 128
 
 
 # semi-intelligently format cards in any format
@@ -650,7 +658,7 @@ class TimedPlayer(object):
 CANDISCARD = 128
 
 
-def format_intention(i):
+def format_intention(i: int | str | Intent) -> str:
     if isinstance(i, str):
         return i
     if i == PLAY:
@@ -712,7 +720,7 @@ def pretend(action, knowledge, intentions, hand, board):
             # print("would cause them to play", f(c))
             return False, 0, predictions + [PLAY]
 
-        if action == DISCARD and i not in [DISCARD, CANDISCARD]:
+        if action == DISCARD and i not in {Intent.DISCARD, Intent.CAN_DISCARD}:
             # print("would cause them to discard", f(c))
             return False, 0, predictions + [DISCARD]
 
@@ -720,7 +728,7 @@ def pretend(action, knowledge, intentions, hand, board):
             pos = True
             predictions.append(PLAY)
             score += 3
-        elif action == DISCARD and i in [DISCARD, CANDISCARD]:
+        elif action == DISCARD and i in {Intent.DISCARD, Intent.CAN_DISCARD}:
             pos = True
             predictions.append(DISCARD)
             if i == DISCARD:

--- a/hanabi.py
+++ b/hanabi.py
@@ -4,6 +4,7 @@ import random
 import sys
 import copy
 import time
+from typing import Final
 
 GREEN = 0
 YELLOW = 1
@@ -121,9 +122,11 @@ class Action(object):
         )
 
 
-class Player(object):
-    def __init__(self, name, pnr):
+class Player:
+    def __init__(self, name, hand_size=5):
         self.name = name
+        self._hand_size: Final[int] = hand_size
+
         self.explanation = []
 
     def get_action(
@@ -185,7 +188,7 @@ def update_knowledge(knowledge, used):
 
 class InnerStatePlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name, pnr)
+        super().__init__(name)
 
     def get_action(
         self, nr, hands, knowledge, trash, played, board, valid_actions, hints
@@ -246,7 +249,7 @@ class InnerStatePlayer(Player):
 
 class OuterStatePlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name, pnr)
+        super().__init__(name)
         self.hints = {}
         self.pnr = pnr
 
@@ -379,7 +382,7 @@ a = 1
 
 class SelfRecognitionPlayer(Player):
     def __init__(self, name, pnr, other=OuterStatePlayer):
-        super().__init__(name, pnr)
+        super().__init__(name)
         self.hints = {}
         self.pnr = pnr
         self.gothint = None
@@ -779,7 +782,7 @@ def format_knowledge(k):
 
 class IntentionalPlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name, pnr)
+        super().__init__(name)
         self.hints = {}
         self.pnr = pnr
         self.gothint = None
@@ -932,7 +935,7 @@ class IntentionalPlayer(Player):
 
 class SelfIntentionalPlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name, pnr)
+        super().__init__(name)
         self.hints = {}
         self.pnr = pnr
         self.gothint = None
@@ -1139,7 +1142,7 @@ for c in ALL_COLORS:
 
 class SamplingRecognitionPlayer(Player):
     def __init__(self, name, pnr, other=IntentionalPlayer, maxtime=5000):
-        super().__init__(name, pnr)
+        super().__init__(name)
         self.hints = {}
         self.pnr = pnr
         self.gothint = None
@@ -1321,7 +1324,7 @@ class SamplingRecognitionPlayer(Player):
 
 class FullyIntentionalPlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name, pnr)
+        super().__init__(name)
         self.hints = {}
         self.pnr = pnr
         self.gothint = None

--- a/hanabi.py
+++ b/hanabi.py
@@ -4,7 +4,7 @@ import random
 import sys
 import copy
 import time
-from enum import IntEnum
+from enum import IntEnum, Enum, unique
 from typing import Final
 
 GREEN = 0
@@ -89,22 +89,30 @@ def iscard(x):
     return knowledge
 
 
-HINT_COLOR = 0
-HINT_NUMBER = 1
-PLAY = 2
-DISCARD = 3
-
-
 class Action:
-    def __init__(self, type, pnr=None, col=None, num=None, cnr=None):
-        self.type = type
+    @unique
+    class ActionType(Enum):
+        HINT_COLOR = 0
+        HINT_NUMBER = 1
+        PLAY = 2
+        DISCARD = 3
+
+        def __str__(self) -> str:
+            return str(self.value)
+
+    action_type: ActionType
+
+    def __init__(
+        self, action_type: ActionType, pnr=None, col=None, num=None, cnr=None
+    ) -> None:
+        self.action_type = action_type
         self.pnr = pnr
         self.col = col
         self.num = num
         self.cnr = cnr
 
     def __str__(self):
-        if self.type == HINT_COLOR:
+        if self.action_type == Action.ActionType.HINT_COLOR:
             return (
                 "hints "
                 + str(self.pnr)
@@ -112,16 +120,16 @@ class Action:
                 + COLORNAMES[self.col]
                 + " cards"
             )
-        if self.type == HINT_NUMBER:
+        if self.action_type == Action.ActionType.HINT_NUMBER:
             return "hints " + str(self.pnr) + " about all their " + str(self.num)
-        if self.type == PLAY:
+        if self.action_type == Action.ActionType.PLAY:
             return "plays their " + str(self.cnr)
-        if self.type == DISCARD:
+        if self.action_type == Action.ActionType.DISCARD:
             return "discards their " + str(self.cnr)
 
     def __eq__(self, other):
-        return (self.type, self.pnr, self.col, self.num, self.cnr) == (
-            other.type,
+        return (self.action_type, self.pnr, self.col, self.num, self.cnr) == (
+            other.action_type,
             other.pnr,
             other.col,
             other.num,
@@ -207,12 +215,12 @@ class InnerStatePlayer(Player):
         discards = []
         for i, p in enumerate(possible):
             if playable(p, board):
-                return Action(PLAY, cnr=i)
+                return Action(Action.ActionType.PLAY, cnr=i)
             if discardable(p, board):
                 discards.append(i)
 
         if discards:
-            return Action(DISCARD, cnr=random.choice(discards))
+            return Action(Action.ActionType.DISCARD, cnr=random.choice(discards))
 
         playables = []
         for i, h in enumerate(hands):
@@ -224,8 +232,8 @@ class InnerStatePlayer(Player):
         if playables and hints > 0:
             i, j = playables[0]
             if random.random() < 0.5:
-                return Action(HINT_COLOR, pnr=i, col=hands[i][j][0])
-            return Action(HINT_NUMBER, pnr=i, num=hands[i][j][1])
+                return Action(Action.ActionType.HINT_COLOR, pnr=i, col=hands[i][j][0])
+            return Action(Action.ActionType.HINT_NUMBER, pnr=i, num=hands[i][j][1])
 
         for i, k in enumerate(knowledge):
             if i == nr:
@@ -234,21 +242,26 @@ class InnerStatePlayer(Player):
             random.shuffle(cards)
             c = cards[0]
             (col, num) = hands[i][c]
-            hinttype = [HINT_COLOR, HINT_NUMBER]
+            hinttype = [Action.ActionType.HINT_COLOR, Action.ActionType.HINT_NUMBER]
             if hinttype and hints > 0:
-                if random.choice(hinttype) == HINT_COLOR:
-                    return Action(HINT_COLOR, pnr=i, col=col)
+                if random.choice(hinttype) == Action.ActionType.HINT_COLOR:
+                    return Action(Action.ActionType.HINT_COLOR, pnr=i, col=col)
                 else:
-                    return Action(HINT_NUMBER, pnr=i, num=num)
+                    return Action(Action.ActionType.HINT_NUMBER, pnr=i, num=num)
 
         prefer = []
         for v in valid_actions:
-            if v.type in [HINT_COLOR, HINT_NUMBER]:
+            if v.action_type in {
+                Action.ActionType.HINT_COLOR,
+                Action.ActionType.HINT_NUMBER,
+            }:
                 prefer.append(v)
         prefer = []
         if prefer and hints > 0:
             return random.choice(prefer)
-        return random.choice([Action(DISCARD, cnr=i) for i in range(len(knowledge[0]))])
+        return random.choice(
+            [Action(Action.ActionType.DISCARD, cnr=i) for i in range(len(knowledge[0]))]
+        )
 
     def inform(self, action, player, game):
         pass
@@ -272,12 +285,12 @@ class OuterStatePlayer(Player):
         duplicates = []
         for i, p in enumerate(possible):
             if playable(p, board):
-                return Action(PLAY, cnr=i)
+                return Action(Action.ActionType.PLAY, cnr=i)
             if discardable(p, board):
                 discards.append(i)
 
         if discards:
-            return Action(DISCARD, cnr=random.choice(discards))
+            return Action(Action.ActionType.DISCARD, cnr=random.choice(discards))
 
         playables = []
         for i, h in enumerate(hands):
@@ -293,7 +306,7 @@ class OuterStatePlayer(Player):
             real_rank = hands[i][j][0]
             k = knowledge[i][j]
 
-            hinttype = [HINT_COLOR, HINT_NUMBER]
+            hinttype = [Action.ActionType.HINT_COLOR, Action.ActionType.HINT_NUMBER]
             if (j, i) not in self.hints:
                 self.hints[(j, i)] = []
 
@@ -304,12 +317,12 @@ class OuterStatePlayer(Player):
             if hinttype:
                 t = random.choice(hinttype)
 
-            if t == HINT_NUMBER:
-                self.hints[(j, i)].append(HINT_NUMBER)
-                return Action(HINT_NUMBER, pnr=i, num=hands[i][j][1])
-            if t == HINT_COLOR:
-                self.hints[(j, i)].append(HINT_COLOR)
-                return Action(HINT_COLOR, pnr=i, col=hands[i][j][0])
+            if t == Action.ActionType.HINT_NUMBER:
+                self.hints[(j, i)].append(Action.ActionType.HINT_NUMBER)
+                return Action(Action.ActionType.HINT_NUMBER, pnr=i, num=hands[i][j][1])
+            if t == Action.ActionType.HINT_COLOR:
+                self.hints[(j, i)].append(Action.ActionType.HINT_COLOR)
+                return Action(Action.ActionType.HINT_COLOR, pnr=i, col=hands[i][j][0])
 
             playables = playables[1:]
 
@@ -320,23 +333,25 @@ class OuterStatePlayer(Player):
             random.shuffle(cards)
             c = cards[0]
             (col, num) = hands[i][c]
-            hinttype = [HINT_COLOR, HINT_NUMBER]
+            hinttype = [Action.ActionType.HINT_COLOR, Action.ActionType.HINT_NUMBER]
             if (c, i) not in self.hints:
                 self.hints[(c, i)] = []
             for h in self.hints[(c, i)]:
                 hinttype.remove(h)
             if hinttype and hints > 0:
-                if random.choice(hinttype) == HINT_COLOR:
-                    self.hints[(c, i)].append(HINT_COLOR)
-                    return Action(HINT_COLOR, pnr=i, col=col)
+                if random.choice(hinttype) == Action.ActionType.HINT_COLOR:
+                    self.hints[(c, i)].append(Action.ActionType.HINT_COLOR)
+                    return Action(Action.ActionType.HINT_COLOR, pnr=i, col=col)
                 else:
-                    self.hints[(c, i)].append(HINT_NUMBER)
-                    return Action(HINT_NUMBER, pnr=i, num=num)
+                    self.hints[(c, i)].append(Action.ActionType.HINT_NUMBER)
+                    return Action(Action.ActionType.HINT_NUMBER, pnr=i, num=num)
 
-        return random.choice([Action(DISCARD, cnr=i) for i in list(range(handsize))])
+        return random.choice(
+            [Action(Action.ActionType.DISCARD, cnr=i) for i in list(range(handsize))]
+        )
 
     def inform(self, action, player, game):
-        if action.type in [PLAY, DISCARD]:
+        if action.action_type in {Action.ActionType.PLAY, Action.ActionType.DISCARD}:
             x = str(action)
             if (action.cnr, player) in self.hints:
                 self.hints[(action.cnr, player)] = []
@@ -388,6 +403,8 @@ a = 1
 
 
 class SelfRecognitionPlayer(Player):
+    gothint: tuple[Action, int] | None
+
     def __init__(self, name, pnr, other=OuterStatePlayer):
         super().__init__(name)
         self.hints = {}
@@ -407,12 +424,12 @@ class SelfRecognitionPlayer(Player):
         if self.gothint:
             possiblehands = []
             wrong = 0
-            used = {}
+            used: dict[tuple[int, int], int] = {}
             for c in ALL_COLORS:
                 for i, cnt in enumerate(COUNTS):
                     used[(c, i + 1)] = 0
-            for c in trash + played:
-                used[c] += 1
+            for c_tup in trash + played:
+                used[c_tup] += 1
 
             for h in generate_hands_simple(knowledge[nr]):
                 newhands = hands[:]
@@ -431,27 +448,6 @@ class SelfRecognitionPlayer(Player):
                 lastact = self.gothint[0]
                 if act == lastact:
                     possiblehands.append(h)
-
-                    def do(c, i):
-                        newhands = hands[:]
-                        h1 = h[:]
-                        h1[i] = c
-                        newhands[nr] = h1
-                        print(
-                            other.get_action(
-                                self.gothint[1],
-                                newhands,
-                                self.last_knowledge,
-                                self.last_trash,
-                                self.last_played,
-                                self.last_board,
-                                valid_actions,
-                                hints + 1,
-                            )
-                        )
-
-                    # import pdb
-                    # pdb.set_trace()
                 else:
                     wrong += 1
             # print(len(possiblehands), "would have led to", self.gothint[0], "and not:", wrong)
@@ -485,12 +481,12 @@ class SelfRecognitionPlayer(Player):
         duplicates = []
         for i, p in enumerate(possible):
             if playable(p, board):
-                return Action(PLAY, cnr=i)
+                return Action(Action.ActionType.PLAY, cnr=i)
             if discardable(p, board):
                 discards.append(i)
 
         if discards:
-            return Action(DISCARD, cnr=random.choice(discards))
+            return Action(Action.ActionType.DISCARD, cnr=random.choice(discards))
 
         playables = []
         for i, h in enumerate(hands):
@@ -506,19 +502,19 @@ class SelfRecognitionPlayer(Player):
             real_rank = hands[i][j][0]
             k = knowledge[i][j]
 
-            hinttype = [HINT_COLOR, HINT_NUMBER]
+            hinttype = [Action.ActionType.HINT_COLOR, Action.ActionType.HINT_NUMBER]
             if (j, i) not in self.hints:
                 self.hints[(j, i)] = []
 
             for h in self.hints[(j, i)]:
                 hinttype.remove(h)
 
-            if HINT_NUMBER in hinttype:
-                self.hints[(j, i)].append(HINT_NUMBER)
-                return Action(HINT_NUMBER, pnr=i, num=hands[i][j][1])
-            if HINT_COLOR in hinttype:
-                self.hints[(j, i)].append(HINT_COLOR)
-                return Action(HINT_COLOR, pnr=i, col=hands[i][j][0])
+            if Action.ActionType.HINT_NUMBER in hinttype:
+                self.hints[(j, i)].append(Action.ActionType.HINT_NUMBER)
+                return Action(Action.ActionType.HINT_NUMBER, pnr=i, num=hands[i][j][1])
+            if Action.ActionType.HINT_COLOR in hinttype:
+                self.hints[(j, i)].append(Action.ActionType.HINT_COLOR)
+                return Action(Action.ActionType.HINT_COLOR, pnr=i, col=hands[i][j][0])
 
             playables = playables[1:]
 
@@ -529,23 +525,25 @@ class SelfRecognitionPlayer(Player):
             random.shuffle(cards)
             c = cards[0]
             (col, num) = hands[i][c]
-            hinttype = [HINT_COLOR, HINT_NUMBER]
+            hinttype = [Action.ActionType.HINT_COLOR, Action.ActionType.HINT_NUMBER]
             if (c, i) not in self.hints:
                 self.hints[(c, i)] = []
             for h in self.hints[(c, i)]:
                 hinttype.remove(h)
             if hinttype and hints > 0:
-                if random.choice(hinttype) == HINT_COLOR:
-                    self.hints[(c, i)].append(HINT_COLOR)
-                    return Action(HINT_COLOR, pnr=i, col=col)
+                if random.choice(hinttype) == Action.ActionType.HINT_COLOR:
+                    self.hints[(c, i)].append(Action.ActionType.HINT_COLOR)
+                    return Action(Action.ActionType.HINT_COLOR, pnr=i, col=col)
                 else:
-                    self.hints[(c, i)].append(HINT_NUMBER)
-                    return Action(HINT_NUMBER, pnr=i, num=num)
+                    self.hints[(c, i)].append(Action.ActionType.HINT_NUMBER)
+                    return Action(Action.ActionType.HINT_NUMBER, pnr=i, num=num)
 
-        return random.choice([Action(DISCARD, cnr=i) for i in list(range(handsize))])
+        return random.choice(
+            [Action(Action.ActionType.DISCARD, cnr=i) for i in list(range(handsize))]
+        )
 
     def inform(self, action, player, game):
-        if action.type in [PLAY, DISCARD]:
+        if action.action_type in {Action.ActionType.PLAY, Action.ActionType.DISCARD}:
             x = str(action)
             if (action.cnr, player) in self.hints:
                 self.hints[(action.cnr, player)] = []
@@ -579,7 +577,7 @@ def priorities(c, board):
     return 6 + (4 - val)
 
 
-SENT = 0
+SENT: float = 0
 ERRORS = 0
 COUNT = 0
 
@@ -629,11 +627,13 @@ class TimedPlayer:
 
         delta += hands[other].index(other_hand[0])
         if duration >= 5:
-            action = Action(DISCARD, cnr=fix(duration - 5))
+            action = Action(Action.ActionType.DISCARD, cnr=fix(duration - 5))
         else:
-            action = Action(PLAY, cnr=fix(duration))
+            action = Action(Action.ActionType.PLAY, cnr=fix(duration))
         if self.last_played and hints > 0 and CAREFUL:
-            action = Action(HINT_COLOR, pnr=other, col=other_hand[0][0])
+            action = Action(
+                Action.ActionType.HINT_COLOR, pnr=other, col=other_hand[0][0]
+            )
         t1 = time.time()
         SENT = delta
         # print(self.pnr, "convey", round(delta))
@@ -645,7 +645,7 @@ class TimedPlayer:
         return action
 
     def inform(self, action, player, game):
-        self.last_played = action.type == PLAY
+        self.last_played = action.action_type == Action.ActionType.PLAY
         self.last_tick = self.tt
         self.tt = time.time()
         # print(action, player)
@@ -660,33 +660,36 @@ CANDISCARD = 128
 def format_intention(i: int | str | Intent | None) -> str:
     if isinstance(i, str):
         return i
-    if i == PLAY:
+    if i == Intent.PLAY:
         return "Play"
-    elif i == DISCARD:
+    elif i == Intent.DISCARD:
         return "Discard"
-    elif i == CANDISCARD:
+    elif i == Intent.CAN_DISCARD:
         return "Can Discard"
-    return "Keep"
+    elif i is None:
+        return "Keep"
+    else:
+        raise ValueError("Unexpected intent value")
 
 
-def whattodo(knowledge, pointed, board):
+def whattodo(knowledge, pointed, board) -> Action.ActionType | None:
     possible = get_possible(knowledge)
     play = potentially_playable(possible, board)
     discard = potentially_discardable(possible, board)
 
     if play and pointed:
-        return PLAY
+        return Action.ActionType.PLAY
     if discard and pointed:
-        return DISCARD
+        return Action.ActionType.DISCARD
     return None
 
 
 def pretend(action, knowledge, intentions, hand, board):
-    (type, value) = action
+    (action_type, value) = action
     positive = []
     haspositive = False
     change = False
-    if type == HINT_COLOR:
+    if action_type == Action.ActionType.HINT_COLOR:
         newknowledge = []
         for i, (col, num) in enumerate(hand):
             positive.append(value == col)
@@ -710,26 +713,32 @@ def pretend(action, knowledge, intentions, hand, board):
     if not change:
         return False, 0, ["No new information"]
     score = 0
-    predictions = []
+    predictions: list[Intent | None] = []
     pos = False
     for i, c, k, p in zip(intentions, hand, newknowledge, positive):
-        action = whattodo(k, p, board)
+        predicted_action = whattodo(k, p, board)
 
-        if action == PLAY and i != PLAY:
+        if predicted_action == Action.ActionType.PLAY and i != Intent.PLAY:
             # print("would cause them to play", f(c))
-            return False, 0, predictions + [PLAY]
+            return False, 0, predictions + [Intent.PLAY]
 
-        if action == DISCARD and i not in {Intent.DISCARD, Intent.CAN_DISCARD}:
+        if predicted_action == Action.ActionType.DISCARD and i not in {
+            Intent.DISCARD,
+            Intent.CAN_DISCARD,
+        }:
             # print("would cause them to discard", f(c))
-            return False, 0, predictions + [DISCARD]
+            return False, 0, predictions + [Intent.DISCARD]
 
-        if action == PLAY and i == PLAY:
+        if predicted_action == Action.ActionType.PLAY and i == Intent.PLAY:
             pos = True
-            predictions.append(PLAY)
+            predictions.append(Intent.PLAY)
             score += 3
-        elif action == DISCARD and i in {Intent.DISCARD, Intent.CAN_DISCARD}:
+        elif predicted_action == Action.ActionType.DISCARD and i in {
+            Intent.DISCARD,
+            Intent.CAN_DISCARD,
+        }:
             pos = True
-            predictions.append(DISCARD)
+            predictions.append(Intent.DISCARD)
             if i == Intent.DISCARD:
                 score += 2
             else:
@@ -814,33 +823,33 @@ class IntentionalPlayer(Player):
         duplicates = []
         for i, p in enumerate(possible):
             if playable(p, board):
-                result = Action(PLAY, cnr=i)
+                result = Action(Action.ActionType.PLAY, cnr=i)
             if discardable(p, board):
                 discards.append(i)
 
         if discards and hints < 8 and not result:
-            result = Action(DISCARD, cnr=random.choice(discards))
+            result = Action(Action.ActionType.DISCARD, cnr=random.choice(discards))
 
         playables = []
         useless = []
         discardables = []
         othercards = trash + board
-        intentions = [None for _ in range(handsize)]
+        intentions: list[Intent | None] = [None for _ in range(handsize)]
         for i, h in enumerate(hands):
             if i != nr:
                 for j, x in enumerate(h):
                     (col, n) = x
                     if board[col][1] + 1 == n:
                         playables.append((i, j))
-                        intentions[j] = PLAY
+                        intentions[j] = Intent.PLAY
                     if board[col][1] >= n:
                         useless.append((i, j))
                         if not intentions[j]:
-                            intentions[j] = DISCARD
+                            intentions[j] = Intent.DISCARD
                     if n < 5 and (col, n) not in othercards:
                         discardables.append((i, j))
                         if not intentions[j]:
-                            intentions[j] = CANDISCARD
+                            intentions[j] = Intent.CAN_DISCARD
 
         self.explanation.append(
             ["Intentions"] + list(map(format_intention, intentions))
@@ -849,7 +858,7 @@ class IntentionalPlayer(Player):
         if hints > 0:
             valid = []
             for c in ALL_COLORS:
-                action = (HINT_COLOR, c)
+                action = (Action.ActionType.HINT_COLOR, c)
                 # print("HINT", COLORNAMES[c],)
                 (isvalid, score, expl) = pretend(
                     action, knowledge[1 - nr], intentions, hands[1 - nr], board
@@ -864,7 +873,7 @@ class IntentionalPlayer(Player):
 
             for r in range(5):
                 r += 1
-                action = (HINT_NUMBER, r)
+                action = (Action.ActionType.HINT_NUMBER, r)
                 # print("HINT", r,)
 
                 (isvalid, score, expl) = pretend(
@@ -882,15 +891,17 @@ class IntentionalPlayer(Player):
                 valid.sort(key=lambda x: -x[1])
                 # print(valid)
                 (a, s) = valid[0]
-                if a[0] == HINT_COLOR:
-                    result = Action(HINT_COLOR, pnr=1 - nr, col=a[1])
+                if a[0] == Action.ActionType.HINT_COLOR:
+                    result = Action(Action.ActionType.HINT_COLOR, pnr=1 - nr, col=a[1])
                 else:
-                    result = Action(HINT_NUMBER, pnr=1 - nr, num=a[1])
+                    result = Action(Action.ActionType.HINT_NUMBER, pnr=1 - nr, num=a[1])
 
         self.explanation.append(
             ["My Knowledge"] + list(map(format_knowledge, knowledge[nr]))
         )
-        possible = [Action(DISCARD, cnr=i) for i in list(range(handsize))]
+        possible = [
+            Action(Action.ActionType.DISCARD, cnr=i) for i in list(range(handsize))
+        ]
 
         scores = list(
             map(lambda p: pretend_discard(p, knowledge[nr], board, trash), possible)
@@ -919,10 +930,12 @@ class IntentionalPlayer(Player):
             return result
         return scores[0][0]
 
-        return random.choice([Action(DISCARD, cnr=i) for i in list(range(handsize))])
+        return random.choice(
+            [Action(Action.ActionType.DISCARD, cnr=i) for i in list(range(handsize))]
+        )
 
     def inform(self, action, player, game):
-        if action.type in [PLAY, DISCARD]:
+        if action.action_type in {Action.ActionType.PLAY, Action.ActionType.DISCARD}:
             x = str(action)
             if (action.cnr, player) in self.hints:
                 self.hints[(action.cnr, player)] = []
@@ -961,10 +974,10 @@ class SelfIntentionalPlayer(Player):
         action = []
         if self.gothint:
             (act, plr) = self.gothint
-            if act.type == HINT_COLOR:
+            if act.action_type == Action.ActionType.HINT_COLOR:
                 for k in knowledge[nr]:
                     action.append(whattodo(k, sum(k[act.col]) > 0, board))
-            elif act.type == HINT_NUMBER:
+            elif act.action_type == Action.ActionType.HINT_NUMBER:
                 for k in knowledge[nr]:
                     cnt = 0
                     for c in ALL_COLORS:
@@ -973,48 +986,58 @@ class SelfIntentionalPlayer(Player):
 
         if action:
             self.explanation.append(
-                ["What you want me to do"] + list(map(format_intention, action))
+                ["What you want me to do"]
+                + list(
+                    map(
+                        format_intention,
+                        (
+                            x.value if isinstance(x, Action.ActionType) else None
+                            for x in action
+                        ),
+                    )
+                )
             )
             for i, a in enumerate(action):
-                if a == PLAY and (not result or result.type == DISCARD):
-                    result = Action(PLAY, cnr=i)
-                elif a == DISCARD and not result:
-                    result = Action(DISCARD, cnr=i)
+                if a == Action.ActionType.PLAY and (
+                    not result or result.action_type == Action.ActionType.DISCARD
+                ):
+                    result = Action(Action.ActionType.PLAY, cnr=i)
+                elif a == Action.ActionType.DISCARD and not result:
+                    result = Action(Action.ActionType.DISCARD, cnr=i)
 
         self.gothint = None
         for k in knowledge[nr]:
             possible.append(get_possible(k))
 
         discards = []
-        duplicates = []
         for i, p in enumerate(possible):
             if playable(p, board) and not result:
-                result = Action(PLAY, cnr=i)
+                result = Action(Action.ActionType.PLAY, cnr=i)
             if discardable(p, board):
                 discards.append(i)
 
         if discards and hints < 8 and not result:
-            result = Action(DISCARD, cnr=random.choice(discards))
+            result = Action(Action.ActionType.DISCARD, cnr=random.choice(discards))
 
         playables = []
         useless = []
         discardables = []
         othercards = trash + board
-        intentions = [None for i in list(range(handsize))]
+        intentions: list[Intent | None] = [None for _ in list(range(handsize))]
         for i, h in enumerate(hands):
             if i != nr:
                 for j, (col, n) in enumerate(h):
                     if board[col][1] + 1 == n:
                         playables.append((i, j))
-                        intentions[j] = PLAY
+                        intentions[j] = Intent.PLAY
                     if board[col][1] >= n:
                         useless.append((i, j))
                         if not intentions[j]:
-                            intentions[j] = DISCARD
+                            intentions[j] = Intent.DISCARD
                     if n < 5 and (col, n) not in othercards:
                         discardables.append((i, j))
                         if not intentions[j]:
-                            intentions[j] = CANDISCARD
+                            intentions[j] = Intent.CAN_DISCARD
 
         self.explanation.append(
             ["Intentions"] + list(map(format_intention, intentions))
@@ -1023,7 +1046,7 @@ class SelfIntentionalPlayer(Player):
         if hints > 0:
             valid = []
             for c in ALL_COLORS:
-                action = (HINT_COLOR, c)
+                action = (Action.ActionType.HINT_COLOR, c)
                 # print("HINT", COLORNAMES[c],)
                 (isvalid, score, expl) = pretend(
                     action, knowledge[1 - nr], intentions, hands[1 - nr], board
@@ -1038,7 +1061,7 @@ class SelfIntentionalPlayer(Player):
 
             for r in range(5):
                 r += 1
-                action = (HINT_NUMBER, r)
+                action = (Action.ActionType.HINT_NUMBER, r)
                 # print("HINT", r,)
 
                 (isvalid, score, expl) = pretend(
@@ -1056,15 +1079,17 @@ class SelfIntentionalPlayer(Player):
                 valid.sort(key=lambda x: -x[1])
                 # print(valid)
                 (a, s) = valid[0]
-                if a[0] == HINT_COLOR:
-                    result = Action(HINT_COLOR, pnr=1 - nr, col=a[1])
+                if a[0] == Action.ActionType.HINT_COLOR:
+                    result = Action(Action.ActionType.HINT_COLOR, pnr=1 - nr, col=a[1])
                 else:
-                    result = Action(HINT_NUMBER, pnr=1 - nr, num=a[1])
+                    result = Action(Action.ActionType.HINT_NUMBER, pnr=1 - nr, num=a[1])
 
         self.explanation.append(
             ["My Knowledge"] + list(map(format_knowledge, knowledge[nr]))
         )
-        possible = [Action(DISCARD, cnr=i) for i in list(range(handsize))]
+        possible = [
+            Action(Action.ActionType.DISCARD, cnr=i) for i in list(range(handsize))
+        ]
 
         scores = list(
             map(lambda p: pretend_discard(p, knowledge[nr], board, trash), possible)
@@ -1093,10 +1118,12 @@ class SelfIntentionalPlayer(Player):
             return result
         return scores[0][0]
 
-        return random.choice([Action(DISCARD, cnr=i) for i in list(range(handsize))])
+        return random.choice(
+            [Action(Action.ActionType.DISCARD, cnr=i) for i in list(range(handsize))]
+        )
 
     def inform(self, action, player, game):
-        if action.type in [PLAY, DISCARD]:
+        if action.action_type in {Action.ActionType.PLAY, Action.ActionType.DISCARD}:
             x = str(action)
             if (action.cnr, player) in self.hints:
                 self.hints[(action.cnr, player)] = []
@@ -1251,12 +1278,12 @@ class SamplingRecognitionPlayer(Player):
         duplicates = []
         for i, p in enumerate(possible):
             if playable(p, board):
-                return Action(PLAY, cnr=i)
+                return Action(Action.ActionType.PLAY, cnr=i)
             if discardable(p, board):
                 discards.append(i)
 
         if discards:
-            return Action(DISCARD, cnr=random.choice(discards))
+            return Action(Action.ActionType.DISCARD, cnr=random.choice(discards))
 
         playables = []
         for i, h in enumerate(hands):
@@ -1272,19 +1299,19 @@ class SamplingRecognitionPlayer(Player):
             real_rank = hands[i][j][0]
             k = knowledge[i][j]
 
-            hinttype = [HINT_COLOR, HINT_NUMBER]
+            hinttype = [Action.ActionType.HINT_COLOR, Action.ActionType.HINT_NUMBER]
             if (j, i) not in self.hints:
                 self.hints[(j, i)] = []
 
             for h in self.hints[(j, i)]:
                 hinttype.remove(h)
 
-            if HINT_NUMBER in hinttype:
-                self.hints[(j, i)].append(HINT_NUMBER)
-                return Action(HINT_NUMBER, pnr=i, num=hands[i][j][1])
-            if HINT_COLOR in hinttype:
-                self.hints[(j, i)].append(HINT_COLOR)
-                return Action(HINT_COLOR, pnr=i, col=hands[i][j][0])
+            if Action.ActionType.HINT_NUMBER in hinttype:
+                self.hints[(j, i)].append(Action.ActionType.HINT_NUMBER)
+                return Action(Action.ActionType.HINT_NUMBER, pnr=i, num=hands[i][j][1])
+            if Action.ActionType.HINT_COLOR in hinttype:
+                self.hints[(j, i)].append(Action.ActionType.HINT_COLOR)
+                return Action(Action.ActionType.HINT_COLOR, pnr=i, col=hands[i][j][0])
 
             playables = playables[1:]
 
@@ -1295,23 +1322,25 @@ class SamplingRecognitionPlayer(Player):
             random.shuffle(cards)
             c = cards[0]
             (col, num) = hands[i][c]
-            hinttype = [HINT_COLOR, HINT_NUMBER]
+            hinttype = [Action.ActionType.HINT_COLOR, Action.ActionType.HINT_NUMBER]
             if (c, i) not in self.hints:
                 self.hints[(c, i)] = []
             for h in self.hints[(c, i)]:
                 hinttype.remove(h)
             if hinttype and hints > 0:
-                if random.choice(hinttype) == HINT_COLOR:
-                    self.hints[(c, i)].append(HINT_COLOR)
-                    return Action(HINT_COLOR, pnr=i, col=col)
+                if random.choice(hinttype) == Action.ActionType.HINT_COLOR:
+                    self.hints[(c, i)].append(Action.ActionType.HINT_COLOR)
+                    return Action(Action.ActionType.HINT_COLOR, pnr=i, col=col)
                 else:
-                    self.hints[(c, i)].append(HINT_NUMBER)
-                    return Action(HINT_NUMBER, pnr=i, num=num)
+                    self.hints[(c, i)].append(Action.ActionType.HINT_NUMBER)
+                    return Action(Action.ActionType.HINT_NUMBER, pnr=i, num=num)
 
-        return random.choice([Action(DISCARD, cnr=i) for i in list(range(handsize))])
+        return random.choice(
+            [Action(Action.ActionType.DISCARD, cnr=i) for i in list(range(handsize))]
+        )
 
     def inform(self, action, player, game):
-        if action.type in [PLAY, DISCARD]:
+        if action.action_type in {Action.ActionType.PLAY, Action.ActionType.DISCARD}:
             x = str(action)
             if (action.cnr, player) in self.hints:
                 self.hints[(action.cnr, player)] = []
@@ -1362,26 +1391,26 @@ class FullyIntentionalPlayer(Player):
         useless = []
         discardables = []
         othercards = trash + board
-        intentions = [None for i in list(range(handsize))]
+        intentions: list[Intent | None] = [None for _ in list(range(handsize))]
         for i, h in enumerate(hands):
             if i != nr:
                 for j, (col, n) in enumerate(h):
                     if board[col][1] + 1 == n:
                         playables.append((i, j))
-                        intentions[j] = PLAY
+                        intentions[j] = Intent.PLAY
                     if board[col][1] <= n:
                         useless.append((i, j))
                         if not intentions[j]:
-                            intentions[j] = DISCARD
+                            intentions[j] = Intent.DISCARD
                     if n < 5 and (col, n) not in othercards:
                         discardables.append((i, j))
                         if not intentions[j]:
-                            intentions[j] = CANDISCARD
+                            intentions[j] = Intent.CAN_DISCARD
 
         if hints > 0:
             valid = []
             for c in ALL_COLORS:
-                action = (HINT_COLOR, c)
+                action = (Action.ActionType.HINT_COLOR, c)
                 # print("HINT", COLORNAMES[c],)
                 (isvalid, score) = pretend(
                     action, knowledge[1 - nr], intentions, hands[1 - nr], board
@@ -1392,7 +1421,7 @@ class FullyIntentionalPlayer(Player):
 
             for r in range(5):
                 r += 1
-                action = (HINT_NUMBER, r)
+                action = (Action.ActionType.HINT_NUMBER, r)
                 # print("HINT", r,)
                 (isvalid, score) = pretend(
                     action, knowledge[1 - nr], intentions, hands[1 - nr], board
@@ -1404,10 +1433,10 @@ class FullyIntentionalPlayer(Player):
                 valid.sort(key=lambda x: -x[1])
                 # print(valid)
                 (a, s) = valid[0]
-                if a[0] == HINT_COLOR:
-                    return Action(HINT_COLOR, pnr=1 - nr, col=a[1])
+                if a[0] == Action.ActionType.HINT_COLOR:
+                    return Action(Action.ActionType.HINT_COLOR, pnr=1 - nr, col=a[1])
                 else:
-                    return Action(HINT_NUMBER, pnr=1 - nr, num=a[1])
+                    return Action(Action.ActionType.HINT_NUMBER, pnr=1 - nr, num=a[1])
 
         for i, k in enumerate(knowledge):
             if i == nr or True:
@@ -1416,23 +1445,25 @@ class FullyIntentionalPlayer(Player):
             random.shuffle(cards)
             c = cards[0]
             (col, num) = hands[i][c]
-            hinttype = [HINT_COLOR, HINT_NUMBER]
+            hinttype = [Action.ActionType.HINT_COLOR, Action.ActionType.HINT_NUMBER]
             if (c, i) not in self.hints:
                 self.hints[(c, i)] = []
             for h in self.hints[(c, i)]:
                 hinttype.remove(h)
             if hinttype and hints > 0:
-                if random.choice(hinttype) == HINT_COLOR:
-                    self.hints[(c, i)].append(HINT_COLOR)
-                    return Action(HINT_COLOR, pnr=i, col=col)
+                if random.choice(hinttype) == Action.ActionType.HINT_COLOR:
+                    self.hints[(c, i)].append(Action.ActionType.HINT_COLOR)
+                    return Action(Action.ActionType.HINT_COLOR, pnr=i, col=col)
                 else:
-                    self.hints[(c, i)].append(HINT_NUMBER)
-                    return Action(HINT_NUMBER, pnr=i, num=num)
+                    self.hints[(c, i)].append(Action.ActionType.HINT_NUMBER)
+                    return Action(Action.ActionType.HINT_NUMBER, pnr=i, num=num)
 
-        return random.choice([Action(DISCARD, cnr=i) for i in list(range(handsize))])
+        return random.choice(
+            [Action(Action.ActionType.DISCARD, cnr=i) for i in list(range(handsize))]
+        )
 
     def inform(self, action, player, game):
-        if action.type in [PLAY, DISCARD]:
+        if action.action_type in {Action.ActionType.PLAY, Action.ActionType.DISCARD}:
             x = str(action)
             if (action.cnr, player) in self.hints:
                 self.hints[(action.cnr, player)] = []
@@ -1507,14 +1538,14 @@ class Game:
             print(
                 "MOVE:",
                 self.current_player,
-                action.type,
+                action.action_type,
                 action.cnr,
                 action.pnr,
                 action.col,
                 action.num,
                 file=self.log,
             )
-        if action.type == HINT_COLOR:
+        if action.action_type == Action.ActionType.HINT_COLOR:
             self.hints -= 1
             print(
                 self.players[self.current_player].name,
@@ -1544,7 +1575,7 @@ class Game:
                 else:
                     for i in range(len(knowledge[action.col])):
                         knowledge[action.col][i] = 0
-        elif action.type == HINT_NUMBER:
+        elif action.action_type == Action.ActionType.HINT_NUMBER:
             self.hints -= 1
             print(
                 self.players[self.current_player].name,
@@ -1573,7 +1604,7 @@ class Game:
                 else:
                     for k in knowledge:
                         k[action.num - 1] = 0
-        elif action.type == PLAY:
+        elif action.action_type == Action.ActionType.PLAY:
             (col, num) = self.hands[self.current_player][action.cnr]
             print(
                 self.players[self.current_player].name,
@@ -1627,15 +1658,19 @@ class Game:
     def valid_actions(self):
         valid = []
         for i in range(len(self.hands[self.current_player])):
-            valid.append(Action(PLAY, cnr=i))
-            valid.append(Action(DISCARD, cnr=i))
+            valid.append(Action(Action.ActionType.PLAY, cnr=i))
+            valid.append(Action(Action.ActionType.DISCARD, cnr=i))
         if self.hints > 0:
             for i, p in enumerate(self.players):
                 if i != self.current_player:
                     for col in set(list(map(lambda x: x[0], self.hands[i]))):
-                        valid.append(Action(HINT_COLOR, pnr=i, col=col))
+                        valid.append(
+                            Action(Action.ActionType.HINT_COLOR, pnr=i, col=col)
+                        )
                     for num in set(list(map(lambda x: x[1], self.hands[i]))):
-                        valid.append(Action(HINT_NUMBER, pnr=i, num=num))
+                        valid.append(
+                            Action(Action.ActionType.HINT_NUMBER, pnr=i, num=num)
+                        )
         return valid
 
     def run(self, turns=-1):

--- a/httpui.py
+++ b/httpui.py
@@ -451,7 +451,7 @@ participantstarts = {}
 
 class HTTPPlayer(hanabi.Player):
     def __init__(self, name, pnr):
-        super().__init__(name, pnr)
+        super().__init__(name)
         self.pnr = pnr
         self.actions = []
         self.knows = [set() for i in range(5)]
@@ -543,7 +543,7 @@ class ReplayHTTPPlayer(HTTPPlayer):
 
 class ReplayPlayer(hanabi.Player):
     def __init__(self, name, pnr):
-        super(ReplayPlayer, self).__init__(name, pnr)
+        super(ReplayPlayer, self).__init__(name)
         self.actions = []
         self.realplayer = None
 

--- a/httpui.py
+++ b/httpui.py
@@ -13,6 +13,8 @@ import consent
 import threading
 from cgi import parse_header, parse_multipart
 from urllib.parse import parse_qs
+
+from self_intentional_with_memory import SelfIntentionalPlayerWithMemory
 from serverconf import HOST_NAME, PORT_NUMBER
 
 
@@ -630,6 +632,7 @@ ais = {
     "self": hanabi.SelfRecognitionPlayer,
     "intentional": hanabi.IntentionalPlayer,
     "full": hanabi.SelfIntentionalPlayer,
+    "full-with-mem": SelfIntentionalPlayerWithMemory,
 }
 
 
@@ -1186,6 +1189,9 @@ class MyHandler(BaseHTTPRequestHandler):
             )
             s.wfile.write(
                 b'<li><a href="/new/full">Fully Intentional Player</a></li>\n'
+            )
+            s.wfile.write(
+                b'<li><a href="/new/full-with-mem">Fully Intentional Player with Memory</a></li>\n'
             )
             s.wfile.write(b"</ul><br/>")
             s.wfile.write(

--- a/httpui.py
+++ b/httpui.py
@@ -451,8 +451,7 @@ participantstarts = {}
 
 class HTTPPlayer(hanabi.Player):
     def __init__(self, name, pnr):
-        super().__init__(name)
-        self.pnr = pnr
+        super().__init__(name, pnr)
         self.actions = []
         self.knows = [set() for i in range(5)]
         self.aiknows = [set() for i in range(5)]
@@ -545,7 +544,7 @@ class HTTPPlayer(hanabi.Player):
 
 class ReplayHTTPPlayer(HTTPPlayer):
     def __init__(self, name, pnr):
-        super(ReplayHTTPPlayer, self).__init__(name, pnr)
+        super().__init__(name, pnr)
         self.actions = []
 
     def get_action(
@@ -556,7 +555,7 @@ class ReplayHTTPPlayer(HTTPPlayer):
 
 class ReplayPlayer(hanabi.Player):
     def __init__(self, name, pnr):
-        super(ReplayPlayer, self).__init__(name)
+        super().__init__(name, pnr)
         self.actions = []
         self.realplayer = None
 

--- a/httpui.py
+++ b/httpui.py
@@ -880,7 +880,7 @@ class MyHandler(BaseHTTPRequestHandler):
                     items = map(lambda s: s.strip(), line.strip().split())
                     const, pnum, type, cnr, pnr, col, num = items
                     a = hanabi.Action(
-                        convert(type),
+                        hanabi.Action.ActionType(convert(type)),
                         convert(pnr),
                         convert(col),
                         convert(num),
@@ -948,7 +948,7 @@ class MyHandler(BaseHTTPRequestHandler):
                     items = map(lambda s: s.strip(), line.strip().split())
                     const, pnum, type, cnr, pnr, col, num = items
                     a = hanabi.Action(
-                        convert(type),
+                        hanabi.Action.ActionType(convert(type)),
                         convert(pnr),
                         convert(col),
                         convert(num),

--- a/httpui.py
+++ b/httpui.py
@@ -1079,7 +1079,9 @@ class MyHandler(BaseHTTPRequestHandler):
             def match(filters, ai, deck, score):
                 if "ai" in filters and ai != filters["ai"]:
                     return False
-                if "score" in filters and (score is None or score // 5 != int(filters["score"])):
+                if "score" in filters and (
+                    score is None or score // 5 != int(filters["score"])
+                ):
                     return False
                 if "deck" in filters and (
                     (str(deck) != filters["deck"] and filters["deck"] != "other")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "mypy>=1.15.0",
     "ruff>=0.9.7",
 ]

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -218,7 +218,7 @@ class SelfIntentionalPlayerWithMemory(Player):
             self._intents_conveyed = [
                 self._intents_conveyed[i]
                 if expl[i] is None
-                and self._intents_conveyed[i] == Action.ActionType.PLAY
+                and self._intents_conveyed[i] == Intent.PLAY
                 else expl[i]
                 for i in range(len(expl))
             ]

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -1,0 +1,176 @@
+import random
+
+from hanabi import Player, HINT_COLOR, whattodo, HINT_NUMBER, ALL_COLORS, format_intention, DISCARD, PLAY, Action, \
+    get_possible, playable, discardable, CANDISCARD, pretend, COLORNAMES, format_knowledge, pretend_discard, f
+
+
+class SelfIntentionalPlayer(Player):
+    def __init__(self, name, pnr):
+        super().__init__(name, pnr)
+        self.hints = {}
+        self.pnr = pnr
+        self.gothint = None
+        self.last_knowledge = []
+        self.last_played = []
+        self.last_board = []
+
+    def get_action(
+        self, nr, hands, knowledge, trash, played, board, valid_actions, hints
+    ):
+        handsize = len(knowledge[0])
+        possible = []
+        result = None
+        self.explanation = []
+        self.explanation.append(["Your Hand:"] + list(map(f, hands[1 - nr])))
+        action = []
+        if self.gothint:
+            (act, plr) = self.gothint
+            if act.type == HINT_COLOR:
+                for k in knowledge[nr]:
+                    action.append(whattodo(k, sum(k[act.col]) > 0, board))
+            elif act.type == HINT_NUMBER:
+                for k in knowledge[nr]:
+                    cnt = 0
+                    for c in ALL_COLORS:
+                        cnt += k[c][act.num - 1]
+                    action.append(whattodo(k, cnt > 0, board))
+
+        if action:
+            self.explanation.append(
+                ["What you want me to do"] + list(map(format_intention, action))
+            )
+            for i, a in enumerate(action):
+                if a == PLAY and (not result or result.type == DISCARD):
+                    result = Action(PLAY, cnr=i)
+                elif a == DISCARD and not result:
+                    result = Action(DISCARD, cnr=i)
+
+        self.gothint = None
+        for k in knowledge[nr]:
+            possible.append(get_possible(k))
+
+        discards = []
+        duplicates = []
+        for i, p in enumerate(possible):
+            if playable(p, board) and not result:
+                result = Action(PLAY, cnr=i)
+            if discardable(p, board):
+                discards.append(i)
+
+        if discards and hints < 8 and not result:
+            result = Action(DISCARD, cnr=random.choice(discards))
+
+        playables = []
+        useless = []
+        discardables = []
+        othercards = trash + board
+        intentions = [None for i in list(range(handsize))]
+        for i, h in enumerate(hands):
+            if i != nr:
+                for j, (col, n) in enumerate(h):
+                    if board[col][1] + 1 == n:
+                        playables.append((i, j))
+                        intentions[j] = PLAY
+                    if board[col][1] >= n:
+                        useless.append((i, j))
+                        if not intentions[j]:
+                            intentions[j] = DISCARD
+                    if n < 5 and (col, n) not in othercards:
+                        discardables.append((i, j))
+                        if not intentions[j]:
+                            intentions[j] = CANDISCARD
+
+        self.explanation.append(
+            ["Intentions"] + list(map(format_intention, intentions))
+        )
+
+        if hints > 0:
+            valid = []
+            for c in ALL_COLORS:
+                action = (HINT_COLOR, c)
+                # print("HINT", COLORNAMES[c],)
+                (isvalid, score, expl) = pretend(
+                    action, knowledge[1 - nr], intentions, hands[1 - nr], board
+                )
+                self.explanation.append(
+                    ["Prediction for: Hint Color " + COLORNAMES[c]]
+                    + list(map(format_intention, expl))
+                )
+                # print(isvalid, score)
+                if isvalid:
+                    valid.append((action, score))
+
+            for r in range(5):
+                r += 1
+                action = (HINT_NUMBER, r)
+                # print("HINT", r,)
+
+                (isvalid, score, expl) = pretend(
+                    action, knowledge[1 - nr], intentions, hands[1 - nr], board
+                )
+                self.explanation.append(
+                    ["Prediction for: Hint Rank " + str(r)]
+                    + list(map(format_intention, expl))
+                )
+                # print(isvalid, score)
+                if isvalid:
+                    valid.append((action, score))
+
+            if valid and not result:
+                valid.sort(key=lambda x: -x[1])
+                # print(valid)
+                (a, s) = valid[0]
+                if a[0] == HINT_COLOR:
+                    result = Action(HINT_COLOR, pnr=1 - nr, col=a[1])
+                else:
+                    result = Action(HINT_NUMBER, pnr=1 - nr, num=a[1])
+
+        self.explanation.append(
+            ["My Knowledge"] + list(map(format_knowledge, knowledge[nr]))
+        )
+        possible = [Action(DISCARD, cnr=i) for i in list(range(handsize))]
+
+        scores = list(
+            map(lambda p: pretend_discard(p, knowledge[nr], board, trash), possible)
+        )
+
+        def format_term(x):
+            (col, rank, _, prob, val) = x
+            return (
+                COLORNAMES[col]
+                + " "
+                + str(rank)
+                + " (%.2f%%): %.2f" % (prob * 100, val)
+            )
+
+        self.explanation.append(
+            ["Discard Scores"]
+            + list(
+                map(
+                    lambda x: "\n".join(map(format_term, x[2])) + "\n%.2f" % (x[1]),
+                    scores,
+                )
+            )
+        )
+        scores.sort(key=lambda x: -x[1])
+        if result:
+            return result
+        return scores[0][0]
+
+    def inform(self, action, player, game):
+        if action.type in [PLAY, DISCARD]:
+            x = str(action)
+            if (action.cnr, player) in self.hints:
+                self.hints[(action.cnr, player)] = []
+            for i in range(10):
+                if (action.cnr + i + 1, player) in self.hints:
+                    self.hints[(action.cnr + i, player)] = self.hints[
+                        (action.cnr + i + 1, player)
+                    ]
+                    self.hints[(action.cnr + i + 1, player)] = []
+        elif action.pnr == self.pnr:
+            self.gothint = (action, player)
+            self.last_knowledge = game.knowledge[:]
+            self.last_board = game.board[:]
+            self.last_trash = game.trash[:]
+            self.played = game.played[:]

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -58,15 +58,10 @@ class SelfIntentionalPlayerWithMemory(Player):
         if action:
             self.explanation.append(
                 ["What you want me to do"]
-                + list(
-                    map(
-                        format_intention,
-                        (
-                            x.value if isinstance(x, Action.ActionType) else None
-                            for x in action
-                        ),
-                    )
-                )
+                + [
+                    x.display_name if isinstance(x, Action.ActionType) else "Keep"
+                    for x in action
+                ]
             )
             for i, a in enumerate(action):
                 if a == Action.ActionType.PLAY and (

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -178,7 +178,7 @@ class SelfIntentionalPlayerWithMemory(Player):
             )
 
             if isvalid:
-                assert all(isinstance(x, int) or x is None for x in expl)
+                assert all(isinstance(x, Intent) or x is None for x in expl)
                 valid.append((action, score, expl))
         for rank in range(5):
             rank += 1
@@ -202,7 +202,7 @@ class SelfIntentionalPlayerWithMemory(Player):
             )
 
             if isvalid:
-                assert all(isinstance(x, int) or x is None for x in expl)
+                assert all(isinstance(x, Intent) or x is None for x in expl)
                 valid.append((action, score, expl))
         if valid and not result:
             valid.sort(key=lambda x: x[1], reverse=True)

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -6,7 +6,7 @@ from hanabi import Player, HINT_COLOR, whattodo, HINT_NUMBER, ALL_COLORS, format
 
 class SelfIntentionalPlayer(Player):
     def __init__(self, name, pnr):
-        super().__init__(name, pnr)
+        super().__init__(name)
         self.hints = {}
         self.pnr = pnr
         self.gothint = None

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -27,14 +27,13 @@ def _intent_unchanged(old: Intent | None, new: Intent | None) -> bool:
 class SelfIntentionalPlayerWithMemory(Player):
     pnr: int
     got_hint: tuple[Action, int] | None
+    _intents_conveyed: list[Intent | None]
 
     def __init__(self, name: str, pnr: int):
         super().__init__(name)
         self.pnr = pnr
         self.got_hint = None
-        self._intents_conveyed: list[Intent | None] = [
-            None for _ in range(self._hand_size)
-        ]
+        self._intents_conveyed = [None for _ in range(self._hand_size)]
 
     def get_action(
         self, pnr: int, hands, knowledge, trash, played, board, valid_actions, hints
@@ -217,8 +216,7 @@ class SelfIntentionalPlayerWithMemory(Player):
 
             self._intents_conveyed = [
                 self._intents_conveyed[i]
-                if expl[i] is None
-                and self._intents_conveyed[i] == Intent.PLAY
+                if expl[i] is None and self._intents_conveyed[i] == Intent.PLAY
                 else expl[i]
                 for i in range(len(expl))
             ]

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -232,7 +232,7 @@ class SelfIntentionalPlayerWithMemory(Player):
     def inform(self, action: Action, player: int, game: Game) -> None:
         if (
             action.action_type in {Action.ActionType.PLAY, Action.ActionType.DISCARD}
-            and action.pnr != self.pnr
+            and player != self.pnr
         ):
             self._rotate_intents(action.cnr)
 

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -25,7 +25,6 @@ from hanabi import (
 class SelfIntentionalPlayerWithMemory(Player):
     def __init__(self, name, pnr):
         super().__init__(name)
-        self.hints = {}
         self.pnr = pnr
         self.gothint = None
         self.last_knowledge = []
@@ -183,23 +182,18 @@ class SelfIntentionalPlayerWithMemory(Player):
             # I assume that result will not be mutated after this block and in the calling code
             if a[0] == HINT_COLOR:
                 result = Action(HINT_COLOR, pnr=1 - nr, col=a[1])
-                self._intents_conveyed = expl
             else:
                 result = Action(HINT_NUMBER, pnr=1 - nr, num=a[1])
-                self._intents_conveyed = expl
+
+            print(f"Old intents: {self._intents_conveyed}")
+            print(f"New intents: {expl}")
+            self._intents_conveyed = expl
         return result
 
     def inform(self, action, player, game):
         if action.type in [PLAY, DISCARD]:
-            x = str(action)
-            if (action.cnr, player) in self.hints:
-                self.hints[(action.cnr, player)] = []
-            for i in range(10):
-                if (action.cnr + i + 1, player) in self.hints:
-                    self.hints[(action.cnr + i, player)] = self.hints[
-                        (action.cnr + i + 1, player)
-                    ]
-                    self.hints[(action.cnr + i + 1, player)] = []
+            ...
+
         elif action.pnr == self.pnr:
             self.gothint = (action, player)
             self.last_knowledge = game.knowledge[:]

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -4,7 +4,7 @@ from hanabi import Player, HINT_COLOR, whattodo, HINT_NUMBER, ALL_COLORS, format
     get_possible, playable, discardable, CANDISCARD, pretend, COLORNAMES, format_knowledge, pretend_discard, f
 
 
-class SelfIntentionalPlayer(Player):
+class SelfIntentionalPlayerWithMemory(Player):
     def __init__(self, name, pnr):
         super().__init__(name)
         self.hints = {}

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -30,8 +30,7 @@ class SelfIntentionalPlayerWithMemory(Player):
     _intents_conveyed: list[Intent | None]
 
     def __init__(self, name: str, pnr: int):
-        super().__init__(name)
-        self.pnr = pnr
+        super().__init__(name, pnr)
         self.got_hint = None
         self._intents_conveyed = [None for _ in range(self._hand_size)]
 

--- a/self_intentional_with_memory.py
+++ b/self_intentional_with_memory.py
@@ -85,45 +85,7 @@ class SelfIntentionalPlayer(Player):
         )
 
         if hints > 0:
-            valid = []
-            for c in ALL_COLORS:
-                action = (HINT_COLOR, c)
-                # print("HINT", COLORNAMES[c],)
-                (isvalid, score, expl) = pretend(
-                    action, knowledge[1 - nr], intentions, hands[1 - nr], board
-                )
-                self.explanation.append(
-                    ["Prediction for: Hint Color " + COLORNAMES[c]]
-                    + list(map(format_intention, expl))
-                )
-                # print(isvalid, score)
-                if isvalid:
-                    valid.append((action, score))
-
-            for r in range(5):
-                r += 1
-                action = (HINT_NUMBER, r)
-                # print("HINT", r,)
-
-                (isvalid, score, expl) = pretend(
-                    action, knowledge[1 - nr], intentions, hands[1 - nr], board
-                )
-                self.explanation.append(
-                    ["Prediction for: Hint Rank " + str(r)]
-                    + list(map(format_intention, expl))
-                )
-                # print(isvalid, score)
-                if isvalid:
-                    valid.append((action, score))
-
-            if valid and not result:
-                valid.sort(key=lambda x: -x[1])
-                # print(valid)
-                (a, s) = valid[0]
-                if a[0] == HINT_COLOR:
-                    result = Action(HINT_COLOR, pnr=1 - nr, col=a[1])
-                else:
-                    result = Action(HINT_NUMBER, pnr=1 - nr, num=a[1])
+            result = self.give_hint(board, hands, intentions, knowledge, nr, result)
 
         self.explanation.append(
             ["My Knowledge"] + list(map(format_knowledge, knowledge[nr]))
@@ -156,6 +118,46 @@ class SelfIntentionalPlayer(Player):
         if result:
             return result
         return scores[0][0]
+
+    def give_hint(self, board, hands, intentions, knowledge, nr, result):
+        valid = []
+        for c in ALL_COLORS:
+            action = (HINT_COLOR, c)
+            # print("HINT", COLORNAMES[c],)
+            (isvalid, score, expl) = pretend(
+                action, knowledge[1 - nr], intentions, hands[1 - nr], board
+            )
+            self.explanation.append(
+                ["Prediction for: Hint Color " + COLORNAMES[c]]
+                + list(map(format_intention, expl))
+            )
+            # print(isvalid, score)
+            if isvalid:
+                valid.append((action, score))
+        for r in range(5):
+            r += 1
+            action = (HINT_NUMBER, r)
+            # print("HINT", r,)
+
+            (isvalid, score, expl) = pretend(
+                action, knowledge[1 - nr], intentions, hands[1 - nr], board
+            )
+            self.explanation.append(
+                ["Prediction for: Hint Rank " + str(r)]
+                + list(map(format_intention, expl))
+            )
+            # print(isvalid, score)
+            if isvalid:
+                valid.append((action, score))
+        if valid and not result:
+            valid.sort(key=lambda x: -x[1])
+            # print(valid)
+            (a, s) = valid[0]
+            if a[0] == HINT_COLOR:
+                result = Action(HINT_COLOR, pnr=1 - nr, col=a[1])
+            else:
+                result = Action(HINT_NUMBER, pnr=1 - nr, num=a[1])
+        return result
 
     def inform(self, action, player, game):
         if action.type in [PLAY, DISCARD]:

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,47 @@ revision = 1
 requires-python = ">=3.10, <3.13"
 
 [[package]]
+name = "mypy"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/f8/65a7ce8d0e09b6329ad0c8d40330d100ea343bd4dd04c4f8ae26462d0a17/mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13", size = 10738433 },
+    { url = "https://files.pythonhosted.org/packages/b4/95/9c0ecb8eacfe048583706249439ff52105b3f552ea9c4024166c03224270/mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559", size = 9861472 },
+    { url = "https://files.pythonhosted.org/packages/84/09/9ec95e982e282e20c0d5407bc65031dfd0f0f8ecc66b69538296e06fcbee/mypy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be68172e9fd9ad8fb876c6389f16d1c1b5f100ffa779f77b1fb2176fcc9ab95b", size = 11611424 },
+    { url = "https://files.pythonhosted.org/packages/78/13/f7d14e55865036a1e6a0a69580c240f43bc1f37407fe9235c0d4ef25ffb0/mypy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7be1e46525adfa0d97681432ee9fcd61a3964c2446795714699a998d193f1a3", size = 12365450 },
+    { url = "https://files.pythonhosted.org/packages/48/e1/301a73852d40c241e915ac6d7bcd7fedd47d519246db2d7b86b9d7e7a0cb/mypy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2e2c2e6d3593f6451b18588848e66260ff62ccca522dd231cd4dd59b0160668b", size = 12551765 },
+    { url = "https://files.pythonhosted.org/packages/77/ba/c37bc323ae5fe7f3f15a28e06ab012cd0b7552886118943e90b15af31195/mypy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:6983aae8b2f653e098edb77f893f7b6aca69f6cffb19b2cc7443f23cce5f4828", size = 9274701 },
+    { url = "https://files.pythonhosted.org/packages/03/bc/f6339726c627bd7ca1ce0fa56c9ae2d0144604a319e0e339bdadafbbb599/mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f", size = 10662338 },
+    { url = "https://files.pythonhosted.org/packages/e2/90/8dcf506ca1a09b0d17555cc00cd69aee402c203911410136cd716559efe7/mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5", size = 9787540 },
+    { url = "https://files.pythonhosted.org/packages/05/05/a10f9479681e5da09ef2f9426f650d7b550d4bafbef683b69aad1ba87457/mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e", size = 11538051 },
+    { url = "https://files.pythonhosted.org/packages/e9/9a/1f7d18b30edd57441a6411fcbc0c6869448d1a4bacbaee60656ac0fc29c8/mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c", size = 12286751 },
+    { url = "https://files.pythonhosted.org/packages/72/af/19ff499b6f1dafcaf56f9881f7a965ac2f474f69f6f618b5175b044299f5/mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f", size = 12421783 },
+    { url = "https://files.pythonhosted.org/packages/96/39/11b57431a1f686c1aed54bf794870efe0f6aeca11aca281a0bd87a5ad42c/mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f", size = 9265618 },
+    { url = "https://files.pythonhosted.org/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd", size = 10793981 },
+    { url = "https://files.pythonhosted.org/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f", size = 9749175 },
+    { url = "https://files.pythonhosted.org/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464", size = 11455675 },
+    { url = "https://files.pythonhosted.org/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee", size = 12410020 },
+    { url = "https://files.pythonhosted.org/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e", size = 12498582 },
+    { url = "https://files.pythonhosted.org/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22", size = 9366614 },
+    { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -54,6 +95,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "ruff" },
 ]
 
@@ -61,7 +103,10 @@ dev = [
 requires-dist = [{ name = "numpy", specifier = ">=2.2.3" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.9.7" }]
+dev = [
+    { name = "mypy", specifier = ">=1.15.0" },
+    { name = "ruff", specifier = ">=0.9.7" },
+]
 
 [[package]]
 name = "ruff"
@@ -86,4 +131,42 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/79/acbc1edd03ac0e2a04ae2593555dbc9990b34090a9729a0c4c0cf20fb595/ruff-0.9.7-py3-none-win32.whl", hash = "sha256:e9ece95b7de5923cbf38893f066ed2872be2f2f477ba94f826c8defdd6ec6b7d", size = 9988751 },
     { url = "https://files.pythonhosted.org/packages/6d/95/67153a838c6b6ba7a2401241fd8a00cd8c627a8e4a0491b8d853dedeffe0/ruff-0.9.7-py3-none-win_amd64.whl", hash = "sha256:3770fe52b9d691a15f0b87ada29c45324b2ace8f01200fb0c14845e499eb0c2c", size = 11002987 },
     { url = "https://files.pythonhosted.org/packages/63/6a/aca01554949f3a401991dc32fe22837baeaccb8a0d868256cbb26a029778/ruff-0.9.7-py3-none-win_arm64.whl", hash = "sha256:b075a700b2533feb7a01130ff656a4ec0d5f340bb540ad98759b8401c32c2037", size = 10177763 },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
 ]


### PR DESCRIPTION
Create a new agent (class `SelfIntentionalPlayerWithMemory`) that plays the same as `SelfIntentionalPlayer`, except it remembers intents that it previously conveyed to the partner.
This change avoids excessive hinting on cards that the partner should already understand are playable.

Also, did some refactoring:
- extract action type constants into the `Action.ActionType` enum
- extract intent type constants into the `Intent` enum
- add type hints and fix a bunch of static typing errors found by mypy
- make hand size a constructor field for `Player` and its subclasses