### PR TITLE
Stop IntAI from discarding with max hint tokens

### DIFF
--- a/game.py
+++ b/game.py
@@ -13,6 +13,7 @@ from utils import (
     format_hand,
     COUNTS,
     format_card,
+    MAX_HINT_TOKENS,
 )
 
 MAX_PLAYERS: Final[int] = 5
@@ -365,7 +366,7 @@ class Game(AbstractGame):
     def __init__(self, players, log=sys.stdout, format=0):
         super().__init__(players)
         self.hits = 3
-        self.hints = 8
+        self.hints = MAX_HINT_TOKENS
         self.current_player = 0
         self.board = [(c, 0) for c in Color]
         self.played = []

--- a/hanabi.py
+++ b/hanabi.py
@@ -130,14 +130,11 @@ def main(args):
         # TODO: change back or add flag
         # g = Game(players, out)
         g = HanasimGame(players, out)
-        try:
-            pts.append(g.run())
-            if (i + 1) % 100 == 0:
-                print("score", pts[-1])
-        except Exception:
-            import traceback
 
-            traceback.print_exc()
+        pts.append(g.run())
+        if (i + 1) % 100 == 0:
+            print("score", pts[-1])
+
     if n < 10:
         print(pts)
     import numpy

--- a/players/self_intentional.py
+++ b/players/self_intentional.py
@@ -213,7 +213,9 @@ class SelfIntentionalPlayer(Player):
         )
         scores.sort(key=lambda x: -x[1])
         if result:
+            assert result in valid_actions
             return result
+        assert scores[0][0] in valid_actions
         return scores[0][0]
 
     def inform(self, action, player, game):

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,10 @@
 import random
 import copy
 from enum import Enum, IntEnum, unique
-
+from typing import Final
 
 COUNTS = [3, 2, 2, 2, 1]
+MAX_HINT_TOKENS: Final[int] = 8
 
 
 @unique


### PR DESCRIPTION
Stop IntAI from illegally discarding when the team already has the maximum of 8 hint tokens.

Now, when no good actions can be found, IntAI will try to give a redundant hint. If not possible, it will give a random hint. The logic change has been documented in the IntAI decision tree.